### PR TITLE
Remove explicit pyflakes dependency

### DIFF
--- a/requirements/requirements_development.txt
+++ b/requirements/requirements_development.txt
@@ -1,6 +1,5 @@
 black==21.5b1
 flake8==3.8.4
 prometheus-client==0.10.1
-pyflakes==2.2.0
 pytest==6.2.4
 requests==2.25.1


### PR DESCRIPTION
This is a dep of flake8 so we should let it handle the
required versions